### PR TITLE
シーズンページ生成スクリプトと新シーズン追加手順の整備 (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # yancya.club
 yancya.club のコンテンツ
+
+## 新シーズン追加手順
+
+やんちゃクラブは100回ごとにシーズンページ（サムネイル100枚 + index.html）を追加する。
+例として 1701-1800 シーズンを追加する場合:
+
+1. **画像を配置する**
+
+   `docs/yancya-club-1701-1800/` を作り、サムネイル画像を
+   `yancya-club-1701-1800.001.jpeg` 〜 `yancya-club-1701-1800.100.jpeg` の命名で置く
+   （連番3桁ゼロ埋め。枚数は100固定でなくてもよい）。
+
+2. **生成スクリプトを実行する**（開始日・終了日は配信日）
+
+   ```sh
+   ruby scripts/new_season.rb docs/yancya-club-1701-1800 2026/05/13 2026/08/20
+   ```
+
+   ディレクトリ内の jpeg を昇順に列挙した `index.html` が生成され、
+   トップページに追記すべき1行が標準出力に表示される。
+   書き込む前に内容を確認したいときは `--dry-run` を付ける。
+
+3. **トップページにリンクを追記する**
+
+   `docs/index.html` の「Past seasons」セクション末尾に、手順2で表示された
+   `<p><a href="yancya-club-1701-1800">やんちゃクラブ１７０１〜１８００</a> (2026/05/13〜2026/08/20)</p>`
+   形式の行を追記する。
+
+4. **push する**
+
+   main に push すると GitHub Pages（`.github/workflows/static.yml`、`docs/` 配信）が自動デプロイする。
+
+### テスト
+
+```sh
+ruby test/new_season_test.rb
+```
+
+生成 HTML が既存の `docs/yancya-club-1601-1700/index.html` と完全一致することを含めて検証する。

--- a/scripts/new_season.rb
+++ b/scripts/new_season.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# 新シーズンページ生成スクリプト
+#
+# 使い方:
+#   ruby scripts/new_season.rb [--dry-run] docs/yancya-club-1701-1800 <開始日> <終了日>
+#
+# 例:
+#   ruby scripts/new_season.rb docs/yancya-club-1701-1800 2026/05/13 2026/08/20
+#
+# 指定ディレクトリ内の jpeg を昇順に列挙して index.html を生成し、
+# トップページ「Past seasons」に追記すべき1行を標準出力に表示する。
+# --dry-run のときは index.html を書き込まず、生成内容を標準出力に表示する。
+
+module NewSeason
+  module_function
+
+  def image_files(dir)
+    Dir.children(dir).grep(/\.jpeg\z/).sort
+  end
+
+  # ディレクトリ名 "yancya-club-1601-1700" から [1601, 1700] を得る
+  def season_range(dir)
+    base = File.basename(dir)
+    m = base.match(/\Ayancya-club-(\d+)-(\d+)\z/)
+    raise ArgumentError, "ディレクトリ名が yancya-club-<開始>-<終了> 形式ではない: #{base}" unless m
+
+    [Integer(m[1], 10), Integer(m[2], 10)]
+  end
+
+  def index_html(dir)
+    from, to = season_range(dir)
+    images = image_files(dir)
+    raise ArgumentError, "jpeg が1枚も見つからない: #{dir}" if images.empty?
+
+    lines = images.map { |name| %(    <div><img src="./#{name}" /></div>) }
+
+    <<~HTML
+      <!DOCTYPE html>
+
+      <head>
+        <meta charset="utf-8">
+        <title>やんちゃクラブ#{from}-#{to}</title>
+        <link rel="stylesheet" type="text/css" href="../css/yancya-club-thumbnail.css">
+      </head>
+
+      <body>
+        <div class="container">
+      #{lines.join("\n")}
+        </div>
+      </body>
+    HTML
+  end
+
+  def past_seasons_line(dir, start_date, end_date)
+    from, to = season_range(dir)
+    label = "やんちゃクラブ#{from}〜#{to}".tr("0-9", "０-９")
+    %(<p><a href="#{File.basename(dir)}">#{label}</a> (#{start_date}〜#{end_date})</p>)
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  dry_run = ARGV.delete("--dry-run")
+  dir, start_date, end_date = ARGV
+
+  unless dir && start_date && end_date
+    warn "使い方: ruby scripts/new_season.rb [--dry-run] <シーズンディレクトリ> <開始日> <終了日>"
+    warn "例:     ruby scripts/new_season.rb docs/yancya-club-1701-1800 2026/05/13 2026/08/20"
+    exit 1
+  end
+
+  begin
+    html = NewSeason.index_html(dir)
+  rescue ArgumentError => e
+    warn e.message
+    exit 1
+  end
+
+  if dry_run
+    puts html
+  else
+    File.write(File.join(dir, "index.html"), html)
+    warn "書き込んだ: #{File.join(dir, 'index.html')} (画像 #{NewSeason.image_files(dir).size} 枚)"
+  end
+
+  puts "トップページ docs/index.html の「Past seasons」に追記する行:"
+  puts NewSeason.past_seasons_line(dir, start_date, end_date)
+end

--- a/test/new_season_test.rb
+++ b/test/new_season_test.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "tmpdir"
+require "fileutils"
+require_relative "../scripts/new_season"
+
+class NewSeasonTest < Minitest::Test
+  REPO_ROOT = File.expand_path("..", __dir__)
+
+  def test_index_html_for_small_fixture
+    Dir.mktmpdir do |tmp|
+      dir = File.join(tmp, "yancya-club-1701-1800")
+      FileUtils.mkdir_p(dir)
+      %w[001 002 003].each do |n|
+        FileUtils.touch(File.join(dir, "yancya-club-1701-1800.#{n}.jpeg"))
+      end
+
+      expected = <<~HTML
+        <!DOCTYPE html>
+
+        <head>
+          <meta charset="utf-8">
+          <title>やんちゃクラブ1701-1800</title>
+          <link rel="stylesheet" type="text/css" href="../css/yancya-club-thumbnail.css">
+        </head>
+
+        <body>
+          <div class="container">
+            <div><img src="./yancya-club-1701-1800.001.jpeg" /></div>
+            <div><img src="./yancya-club-1701-1800.002.jpeg" /></div>
+            <div><img src="./yancya-club-1701-1800.003.jpeg" /></div>
+          </div>
+        </body>
+      HTML
+
+      assert_equal expected, NewSeason.index_html(dir)
+    end
+  end
+
+  def test_index_html_matches_existing_1601_1700_exactly
+    dir = File.join(REPO_ROOT, "docs", "yancya-club-1601-1700")
+    actual_file = File.read(File.join(dir, "index.html"))
+
+    assert_equal actual_file, NewSeason.index_html(dir)
+  end
+
+  def test_images_are_sorted_ascending
+    Dir.mktmpdir do |tmp|
+      dir = File.join(tmp, "yancya-club-1701-1800")
+      FileUtils.mkdir_p(dir)
+      %w[010 002 100].each do |n|
+        FileUtils.touch(File.join(dir, "yancya-club-1701-1800.#{n}.jpeg"))
+      end
+
+      html = NewSeason.index_html(dir)
+      positions = %w[002 010 100].map { |n| html.index("1701-1800.#{n}.jpeg") }
+
+      assert_equal positions.sort, positions
+    end
+  end
+
+  def test_non_jpeg_files_are_ignored
+    Dir.mktmpdir do |tmp|
+      dir = File.join(tmp, "yancya-club-1701-1800")
+      FileUtils.mkdir_p(dir)
+      FileUtils.touch(File.join(dir, "yancya-club-1701-1800.001.jpeg"))
+      FileUtils.touch(File.join(dir, "index.html"))
+      FileUtils.touch(File.join(dir, ".DS_Store"))
+
+      html = NewSeason.index_html(dir)
+
+      assert_includes html, "yancya-club-1701-1800.001.jpeg"
+      refute_includes html, "index.html\""
+      refute_includes html, ".DS_Store"
+    end
+  end
+
+  def test_past_seasons_line_uses_fullwidth_digits
+    line = NewSeason.past_seasons_line("yancya-club-1601-1700", "2026/02/02", "2026/05/12")
+
+    assert_equal '<p><a href="yancya-club-1601-1700">やんちゃクラブ１６０１〜１７００</a> (2026/02/02〜2026/05/12)</p>',
+                 line
+  end
+
+  def test_title_strips_leading_zeros
+    Dir.mktmpdir do |tmp|
+      dir = File.join(tmp, "yancya-club-001-100")
+      FileUtils.mkdir_p(dir)
+      FileUtils.touch(File.join(dir, "yancya-club-001-100.001.jpeg"))
+
+      assert_includes NewSeason.index_html(dir), "<title>やんちゃクラブ1-100</title>"
+    end
+  end
+
+  def test_cli_dry_run_does_not_write
+    Dir.mktmpdir do |tmp|
+      dir = File.join(tmp, "yancya-club-1701-1800")
+      FileUtils.mkdir_p(dir)
+      FileUtils.touch(File.join(dir, "yancya-club-1701-1800.001.jpeg"))
+
+      out = `#{RbConfig.ruby} #{File.join(REPO_ROOT, "scripts", "new_season.rb")} --dry-run #{dir} 2026/05/13 2026/08/20`
+
+      assert_equal 0, $?.exitstatus
+      refute File.exist?(File.join(dir, "index.html")), "dry-run must not write index.html"
+      assert_includes out, "<title>やんちゃクラブ1701-1800</title>"
+      assert_includes out, "やんちゃクラブ１７０１〜１８００"
+    end
+  end
+
+  def test_cli_writes_index_html_and_prints_past_seasons_line
+    Dir.mktmpdir do |tmp|
+      dir = File.join(tmp, "yancya-club-1701-1800")
+      FileUtils.mkdir_p(dir)
+      FileUtils.touch(File.join(dir, "yancya-club-1701-1800.001.jpeg"))
+
+      out = `#{RbConfig.ruby} #{File.join(REPO_ROOT, "scripts", "new_season.rb")} #{dir} 2026/05/13 2026/08/20`
+
+      assert_equal 0, $?.exitstatus
+      assert File.exist?(File.join(dir, "index.html"))
+      assert_includes out, '<p><a href="yancya-club-1701-1800">やんちゃクラブ１７０１〜１８００</a> (2026/05/13〜2026/08/20)</p>'
+    end
+  end
+
+  def test_cli_fails_on_directory_without_jpegs
+    Dir.mktmpdir do |tmp|
+      dir = File.join(tmp, "yancya-club-1701-1800")
+      FileUtils.mkdir_p(dir)
+
+      `#{RbConfig.ruby} #{File.join(REPO_ROOT, "scripts", "new_season.rb")} --dry-run #{dir} 2026/05/13 2026/08/20 2>/dev/null`
+
+      refute_equal 0, $?.exitstatus
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Closes #5

シーズンページ追加を半自動化する `scripts/new_season.rb` と手順書を整備した。

## 内容

- **scripts/new_season.rb**（Ruby 標準ライブラリのみ）
  - `docs/yancya-club-XXXX-YYYY/` 内の jpeg を昇順に列挙して `index.html` を生成（枚数は100固定ではなく実ファイルを列挙）
  - トップページ「Past seasons」へ追記すべき1行を標準出力に表示（開始日・終了日は引数、数字は全角変換）
  - `--dry-run` で書き込みなしのプレビュー可
- **test/new_season_test.rb**（minitest / 9 runs, 23 assertions）
  - 既存 `docs/yancya-club-1601-1700/index.html` と生成 HTML の**完全一致**（空白差ゼロ）を検証
  - ソート順・非 jpeg 除外・先頭ゼロ剥がし・CLI の dry-run / 書き込み / エラー系を検証
- **README.md**: 新シーズン追加手順（画像配置 → スクリプト実行 → トップページ追記 → push で Pages 自動デプロイ）

## 検証

```
$ ruby test/new_season_test.rb
9 runs, 23 assertions, 0 failures, 0 errors, 0 skips
```

CLI dry-run 出力と既存 1601-1700 ページの diff も完全一致を確認済み。

## 配信への影響

GitHub Pages は `.github/workflows/static.yml` で `docs/` を配信しているため、`scripts/`・`test/` の追加は配信内容に影響しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)