### PR TITLE
トップページのTwitterリンクをXコミュニティ(x.yancya.club)に変更

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
   <h2>Links</h2>
   <p>Events: <a href="./events">イベント告知</a></p>
   <p>YouTube: <a href="https://youtube.yancya.club">youtube.yancya.club</a></p>
-  <p>Twitter community: <a href="https://twitter.yancya.club">twitter.yancya.club</a></p>
+  <p>X community: <a href="https://x.yancya.club">x.yancya.club</a></p>
   <p>LINE Open Chat: <a href="https://line.yancya.club">line.yancya.club</a></p>
   <p>Discord: <a href="https://discord.yancya.club">discord.yancya.club</a></p>
   <p>Misskey: <a href="https://misskey.yancya.club">misskey.yancya.club</a></p>


### PR DESCRIPTION
## Summary
- twitter.yancya.club へのリンクを x.yancya.club に変更（リダイレクト設定はユーザー側で対応済み）

## Test plan
- [ ] docs/index.html のリンクが x.yancya.club を指しているか目視確認