### PR TITLE
link-checkerのCI失敗を修正

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   link-checker:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -21,7 +23,9 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           # docsディレクトリ内の全HTMLファイルをチェック
-          args: --verbose --no-progress 'docs/**/*.html'
+          # --root-dir: href="/" のようなルート相対リンクを docs/ 基準で解決する
+          # --exclude-path: _template配下はプレースホルダ画像を含まないテンプレートなので対象外
+          args: --verbose --no-progress --root-dir ./docs --exclude-path 'docs/events/_template' 'docs/**/*.html'
           # 429 (Too Many Requests) はリトライする
           fail: true
         env:


### PR DESCRIPTION
## Summary
- PR #19 の Check Links CI が失敗していた原因を修正
  - `href="/"` のようなルート相対リンクをlycheeが解決できなかった → `--root-dir ./docs` を追加
  - `docs/events/_template/image.webp` が実体のないプレースホルダで毎回リンク切れ扱いされていた → `--exclude-path` で除外
  - 失敗時のissue自動作成が `Resource not accessible by integration` で失敗していた → job に `permissions: issues: write` を追加

## Test plan
- [x] ローカルで `lychee --offline --root-dir ./docs --exclude-path 'docs/events/_template' 'docs/**/*.html'` を実行し 0 Errors を確認
- [ ] このPRのCIでCheck Linksが成功するか確認